### PR TITLE
Add option to specify output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npx twt-dl-cli@latest --help
 ### Example:
 
 ```sh
-npx twt-dl-cli@latest https://twitter.com/mattpocockuk/status/1592130978234900484
+npx twt-dl-cli@latest https://twitter.com/mattpocockuk/status/1592130978234900484 --output /path/to/output.mp4
 ```
 
 ![twt-dl-cli](usage.png)
@@ -88,3 +88,19 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+## Documentation for `--output` flag
+
+The `--output` flag allows you to specify the output path for the downloaded video file. If the `--output` flag is not provided, the output path defaults to the current date.
+
+### Usage
+
+```sh
+npx twt-dl-cli@latest <twitter url> --output <output path>
+```
+
+### Example
+
+```sh
+npx twt-dl-cli@latest https://twitter.com/mattpocockuk/status/1592130978234900484 --output /path/to/output.mp4
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,11 @@ const argv = cli({
       description: "Allow to download video (yes/no)",
       default: "yes",
     },
+    // Parses `--output` as a string
+    output: {
+      type: String,
+      description: "Specify the output path",
+    },
   },
 });
 
@@ -39,7 +44,7 @@ async function main() {
   const video = await downloadVideo(argv._?.twitterUrl);
   console.log(video);
   if (argv.flags.download === "yes" && video) {
-    await downloadFile(video);
+    await downloadFile(video, argv.flags.output);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,8 +50,9 @@ export async function downloadVideo(url?: string) {
 // TODO: add output directory if needed
 export async function downloadFile(
   fileUrl: string,
-  outputFile = join(process.env.PWD ?? process.cwd(), `${Date.now()}.mp4`),
+  outputPath?: string,
 ) {
+  const outputFile = outputPath ?? join(process.env.PWD ?? process.cwd(), `${Date.now()}.mp4`);
   const spinner = ora("Downloading file...").start();
 
   const writeStream = createWriteStream(outputFile);


### PR DESCRIPTION
Fixes #1

Add option to specify output path for downloaded video files.

* **src/index.ts**
  - Add `outputPath` parameter to `downloadFile` function.
  - Update `downloadFile` function to use `outputPath` instead of default path.

* **src/cli.ts**
  - Add `--output` flag to `cli` command.
  - Pass `--output` flag value to `downloadFile` function.

* **README.md**
  - Update usage example to include `--output` flag.
  - Add documentation for `--output` flag.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ben-z/twt-dl-cli/pull/2?shareId=958e85f7-8fea-4ab9-8d50-b22cf242fb72).